### PR TITLE
Correct issue where ffmpeg wrapper doesnt know when video has finished c...

### DIFF
--- a/CM2301/learn/ffmpeg/ffmpeg.py
+++ b/CM2301/learn/ffmpeg/ffmpeg.py
@@ -84,6 +84,12 @@ class Converter(object):
         print ' '.join(self._parse_options())
         thread = threading.Thread(target=self.__conversion)
         thread.start()
+        
+    def _wait(self):
+        self._process.wait()
+        self.completed = True
+        self.is_started = False
+        print "Conversion Completed"
 
     def cancel(self):
         """
@@ -134,6 +140,8 @@ class Converter(object):
         self._process = subprocess.Popen(self._parse_options(),
                                          stdout=subprocess.PIPE, 
                                          stderr=subprocess.PIPE)
+        thread = threading.Thread(target=self._wait)
+        thread.start()
 
         buf = ''
         total_output = ''
@@ -152,6 +160,8 @@ class Converter(object):
             if '\r' in buf:
                 line, buf = buf.split('\r', 1)
                 tmp = pat.findall(line)
+                print self._process
+                print 'return code: ' +  str(self._process.poll())
                 try:
                     parts = tmp[0].split(':')
                 except IndexError:

--- a/CM2301/learn/models.py
+++ b/CM2301/learn/models.py
@@ -435,6 +435,7 @@ class Video(Base):
             
         if converter.completed:
                 self.conversion_progress = 100
+                self.converting = False
                 self.save()
                 
         self.converting = False


### PR DESCRIPTION
...onverting

The ffmpeg wrapper now uses the Popen wait() method to ensure the video
has completed converting before setting the completed flag to be true.
